### PR TITLE
Add login via OAuth2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  tests:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: PHP ${{ matrix.php-versions }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.php-versions >= '8.4' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+    - name: Configure git
+      if: runner.os == 'Windows'
+      run: git config --system core.autocrlf false; git config --system core.eol lf
+
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up PHP ${{ matrix.php-versions }}
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+        ini-values: date.timezone=Europe/Berlin
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+
+    - name: Get Composer Cache Directory
+      id: composer-cache
+      run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: >
+        curl -sSL https://baltocdn.com/xp-framework/xp-runners/distribution/downloads/e/entrypoint/xp-run-8.8.0.sh > xp-run &&
+        composer install --prefer-dist --no-scripts &&
+        echo "vendor/autoload.php" > composer.pth
+
+    - name: Run test suite
+      run: sh xp-run xp.test.Runner -r Dots src/test/php

--- a/README.md
+++ b/README.md
@@ -5,3 +5,28 @@
 [![Requires PHP 8.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-8_0plus.svg)](http://php.net/)
 
 Lightweight asynchronous communication for teams.
+
+## Configuration
+
+```ini
+[mongo]
+connect=mongo://user:password@localhost/one
+database=crews
+
+[redis]
+connect=redis://localhost
+
+[oauth]
+authorize=http://localhost:8443/oauth/common/authorize
+token=http://localhost:8443/oauth/common/token
+userinfo=http://localhost:8443/graph/me
+client=client-id
+secret=client-secret
+scopes[]=user
+
+[user]
+handle="{{id}}"
+first="{{givenName}}"
+name="{{givenName}} {{surname}}"
+mail="{{mail}}"
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Crews
 
+[![Build status on GitHub](https://github.com/thekid/crews/workflows/Tests/badge.svg)](https://github.com/thekid/crews/actions)
 [![Uses XP Framework](https://raw.githubusercontent.com/xp-framework/web/master/static/xp-framework-badge.png)](https://github.com/xp-framework/core)
 [![BSD Licence](https://raw.githubusercontent.com/xp-framework/web/master/static/licence-bsd.png)](https://github.com/xp-framework/core/blob/master/LICENCE.md)
 [![Requires PHP 8.0+](https://raw.githubusercontent.com/xp-framework/web/master/static/php-8_0plus.svg)](http://php.net/)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Lightweight asynchronous communication for teams.
 
 ```ini
 [mongo]
-connect=mongo://user:password@localhost/one
+connect=mongodb://user:password@localhost/one
 database=crews
 
 [redis]

--- a/class.pth
+++ b/class.pth
@@ -1,2 +1,3 @@
 src/main/php/
+src/test/php/
 vendor/autoload.php

--- a/composer.json
+++ b/composer.json
@@ -3,16 +3,18 @@
     "xp-forge/handlebars-templates": "^3.1",
     "xp-forge/frontend": "^6.0",
     "xp-forge/websockets": "^3.0",
-    "xp-forge/mongodb": "^2.1",
+    "xp-forge/mongodb": "^2.2",
     "xp-forge/redis": "^1.0",
+    "xp-forge/web-auth": "^3.7",
+    "xp-forge/sessions": "^3.0",
     "xp-framework/networking": "^10.0",
     "xp-framework/compiler": "^8.17",
     "php": ">=8.0.0"
   },
   "scripts": {
-    "dev": "xp -supervise web -m develop -a 0.0.0.0:8080 de.thekid.crews.App",
-    "serve": "xp -supervise web -a 0.0.0.0:8080 de.thekid.crews.App",
-    "feed": "xp -supervise ws -a 0.0.0.0:8081 de.thekid.crews.Feed",
+    "dev": "xp -supervise web -c . -m develop -a 0.0.0.0:8080 de.thekid.crews.App",
+    "serve": "xp -supervise web -c . -a 0.0.0.0:8080 de.thekid.crews.App",
+    "feed": "xp -supervise ws -c . -a 0.0.0.0:8081 de.thekid.crews.Feed",
     "post-update-cmd": "xp bundle src/main/webapp/static"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,8 @@
 {
+  "name": "thekid/crews",
+  "description": "Lightweight asynchronous communication for teams",
+  "license": "bsd-3-clause",
+
   "require": {
     "xp-forge/handlebars-templates": "^3.1",
     "xp-forge/frontend": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,9 @@
     "xp-framework/compiler": "^8.17",
     "php": ">=8.0.0"
   },
+  "require-dev": {
+    "xp-framework/test": "^1.5"
+  },
   "scripts": {
     "dev": "xp -supervise web -c . -m develop -a 0.0.0.0:8080 de.thekid.crews.App",
     "serve": "xp -supervise web -c . -a 0.0.0.0:8080 de.thekid.crews.App",

--- a/src/main/handlebars/group.handlebars
+++ b/src/main/handlebars/group.handlebars
@@ -2,9 +2,11 @@
   {{#*inline "title"}}{{group.name}}{{/inline}}
   {{#*inline "content"}}
     <div class="page-actions">
-      <div class="buttons">
-        <button hx-get="/group/{{group._id}}/update" hx-target="#description" hx-swap="innerHTML">🖊️ Edit</button>
-      </div>
+      {{#if (is-user group.owner)}}
+        <div class="buttons">
+          <button hx-get="/group/{{group._id}}/update" hx-target="#description" hx-swap="innerHTML">🖊️ Edit</button>
+        </div>
+      {{/if}}
     </div>
     <p id="description">
       {{#with group}}
@@ -29,12 +31,14 @@
             <p {{#if (emoji body)}}class="emoji"{{/if}}>{{body}}</p>
             
             <div class="actions" hx-target="#p{{_id}}">
-              <small>Posted on {{date created}}{{#with updated}}, updated {{date .}}{{/with}}</small>
+              <small>Posted by <b>{{editor.name}}</b> on {{date created}}{{#with updated}}, updated {{date .}}{{/with}}</small>
 
-              <div class="buttons">
-                <button hx-get="/group/{{group}}/posts/{{_id}}/edit" hx-swap="innerHTML">🖊️</button>
-                <button hx-delete="/group/{{group}}/posts/{{_id}}" hx-swap="delete swap:350ms">❌</button>
-              </div>
+              {{#if (is-user editor)}}
+                <div class="buttons">
+                  <button hx-get="/group/{{group}}/posts/{{_id}}/edit" hx-swap="innerHTML">🖊️</button>
+                  <button hx-delete="/group/{{group}}/posts/{{_id}}" hx-swap="delete swap:350ms">❌</button>
+                </div>
+              {{/if}}
             </div>
           </div>
         {{/fragment}}

--- a/src/main/handlebars/index.handlebars
+++ b/src/main/handlebars/index.handlebars
@@ -15,7 +15,7 @@
             <p>{{description}}</p>
 
             <div class="actions">
-              <small>Created on {{date created}}</small>
+              <small>Created by <b>{{owner.name}}</b> on {{date created}}</small>
             </div>
           </div>
         {{/fragment}}

--- a/src/main/handlebars/layout.handlebars
+++ b/src/main/handlebars/layout.handlebars
@@ -11,6 +11,26 @@
       font-family: 'Rubik', sans-serif;
     }
 
+    body {
+      background-color: #ede6e1;
+      margin: 0;
+    }
+
+    nav {
+      background-color: white;
+      padding: 1rem;
+      box-shadow: 0 .25rem .25rem rgb(0 0 0 / .1);
+    }
+
+    #user {
+      text-align: right;
+      font-weight: bold;
+    }
+
+    main {
+      padding: 0 1rem;
+    }
+
     form {
       display: flex;
       flex-direction: column;
@@ -49,10 +69,11 @@
       grid-template-rows: max-content 1fr max-content;
       border: 1px solid rgb(0 0 0 / .2);
       box-shadow: 0 .25rem .25rem rgb(0 0 0 / .1);
+      background-color: white;
     }
 
     .group > * {
-      padding: .5rem;
+      padding: .75rem;
     }
 
     .group h2 {
@@ -74,6 +95,7 @@
       gap: .5rem;
       border: 1px solid rgb(0 0 0 / .2);
       box-shadow: 0 .25rem .25rem rgb(0 0 0 / .1);
+      background-color: white;
     }
 
     .post > * {
@@ -125,10 +147,14 @@
   </style>
 </head>
 <body {{#with request.values.token}}hx-headers='{"X-CSRF-Token": "{{.}}"}'{{/with}}>
-  <h1 class="breadcrumb"><a href="/">Crews</a> ⛵ &raquo; <a href="{{request.uri.path}}">{{> title}}</a></h1>
+  <nav>
+    <div id="user">{{request.values.user.first}}</div>
+  </nav>
 
-  {{> content}}
-
+  <main>
+    <h1 class="breadcrumb"><a href="/">Crews</a> ⛵ &raquo; <a href="{{request.uri.path}}">{{> title}}</a></h1>
+    {{> content}}
+  </main>
   <script src="/static/vendor.js"></script>
 </body>
 </html>

--- a/src/main/php/de/thekid/crews/App.php
+++ b/src/main/php/de/thekid/crews/App.php
@@ -1,24 +1,48 @@
 <?php namespace de\thekid\crews;
 
-use com\mongodb\MongoConnection;
+use com\mongodb\{MongoConnection, Document};
 use io\redis\RedisProtocol;
 use web\Application;
+use web\auth\SessionBased;
+use web\auth\oauth\{OAuth2Flow, BySecret};
 use web\frontend\{Frontend, AssetsFrom, HandlersIn};
+use web\session\InFileSystem;
 
 /** Web frontend */
 class App extends Application {
 
   public function routes() {
-    $conn= new MongoConnection($this->environment->variable('MONGO_URI'));
-    $events= new Events(new RedisProtocol($this->environment->variable('REDIS_URI')));
-    $db= $conn->database($this->environment->variable('MONGO_DB'));
+    $config= $this->environment->properties('config');
+    $conn= new MongoConnection($config->readString('mongo', 'connect'));
+    $events= new Events(new RedisProtocol($config->readString('redis', 'connect')));
+    $db= $conn->database($config->readString('mongo', 'database'));
+
+    $sessions= new InFileSystem($this->environment->tempDir());
+    $sessions->cookies()->insecure('dev' === $this->environment->profile());
+
+    // Map OAuth user to local users
+    $flow= new OAuth2Flow(
+      $config->readString('oauth', 'authorize'),
+      $config->readString('oauth', 'token'),
+      new BySecret($config->readString('oauth', 'client'), $config->readString('oauth', 'secret')),
+      '/',
+      $config->readArray('oauth', 'scopes'),
+    );
+    $auth= new SessionBased($flow, $sessions, $flow->fetchUser($config->readString('oauth', 'userinfo'))
+      ->map(new UserAttributes($config->readSection('user')))
+      ->map(fn($user) => $db->collection('users')
+        ->modify(['handle' => $user['handle']], ['$set' => $user], upsert: true)
+        ->document()
+        ->properties()
+      )
+    );
 
     return [
       '/static' => new AssetsFrom($this->environment->path('src/main/webapp')),
-      '/'       => new Frontend(
+      '/'       => $auth->required(new Frontend(
         new HandlersIn('de.thekid.crews.web', fn($class) => $class->newInstance($db, $events)),
         new Templating($this->environment->path('src/main/handlebars')),
-      ),
+      )),
     ];
   }
 }

--- a/src/main/php/de/thekid/crews/Events.php
+++ b/src/main/php/de/thekid/crews/Events.php
@@ -10,13 +10,14 @@ class Events {
   /** @return peer.Socket */
   public function socket() { return $this->redis->socket(); }
 
-  /** Publish an event in a given group */
-  public function publish(string|ObjectId $group, array<string, mixed> $event): void {
-    $pass= '';
-    foreach ($event as $key => $value) {
-      $pass.= '&'.urlencode($key).'='.urlencode($value);
-    }
-    $this->redis->command('PUBLISH', (string)$group, substr($pass, 1));
+  /** Publish an event of the form `[kind => argument]` in a given group */
+  public function publish(User $user, string|ObjectId $group, array<string, mixed> $event): void {
+    $this->redis->command('PUBLISH', (string)$group, sprintf(
+      'user=%s&kind=%s&argument=%s',
+      $user->id,
+      key($event),
+      current($event)
+    ));
   }
 
   /** Subscribe to updates from a given group */

--- a/src/main/php/de/thekid/crews/Templating.php
+++ b/src/main/php/de/thekid/crews/Templating.php
@@ -11,7 +11,14 @@ class Templating extends Handlebars {
     parent::__construct($templates, [
       new Dates(null),
       new Functions([
-        'emoji' => fn($node, $context, $options) => preg_match('/^\\p{So}+$/u', $options[0]),
+        'emoji'   => fn($node, $context, $options) => preg_match(
+          '/^\\p{So}+$/u',
+          $options[0],
+        ),
+        'is-user' => fn($node, $context, $options) => 0 === strcmp(
+          $options[0]['id'],
+          $context->lookup('request.values.user._id'),
+        )
       ])
     ]);
   }

--- a/src/main/php/de/thekid/crews/User.php
+++ b/src/main/php/de/thekid/crews/User.php
@@ -1,0 +1,22 @@
+<?php namespace de\thekid\crews;
+
+use com\mongodb\ObjectId;
+
+class User {
+  public readonly ObjectId $id;
+
+  /** Creates a new user */
+  public function __construct(private array<string, mixed> $attributes) {
+    $this->id= $attributes['_id'] instanceof ObjectId ? $attributes['_id'] : new ObjectId($attributes['_id']);
+  }
+
+  /** Returns criteria for lookup */
+  public function where(ObjectId $id, string $role): array<string, mixed> {
+    return ['_id' => $id, $role.'.id' => $this->id];
+  }
+
+  /** Returns a reference */
+  public function reference(): array<string, mixed> {
+    return ['id' => $this->id, 'name' => $this->attributes['name']];
+  }
+}

--- a/src/main/php/de/thekid/crews/UserAttributes.php
+++ b/src/main/php/de/thekid/crews/UserAttributes.php
@@ -1,6 +1,10 @@
 <?php namespace de\thekid\crews;
 
-/** Maps user attributes using a handlebars-style syntax */
+/**
+ * Maps user attributes using a handlebars-style syntax
+ *
+ * @test  de.thekid.crews.unittest.UserAttributesTest
+ */
 class UserAttributes {
 
   public function __construct(private array<string, string> $mapping) { }

--- a/src/main/php/de/thekid/crews/UserAttributes.php
+++ b/src/main/php/de/thekid/crews/UserAttributes.php
@@ -1,0 +1,19 @@
+<?php namespace de\thekid\crews;
+
+/** Maps user attributes using a handlebars-style syntax */
+class UserAttributes {
+
+  public function __construct(private array<string, string> $mapping) { }
+
+  public function __invoke($input) {
+    $replace= function($m) use($input) {
+      foreach (explode('.', trim($m[1])) as $segment) {
+        $input= $input[$segment];
+      }
+      return $input;
+    };
+    foreach ($this->mapping as $field => $template) {
+      yield $field => preg_replace_callback('/\{\{([^}]+)\}\}/', $replace, $template);
+    }
+  }
+}

--- a/src/main/php/de/thekid/crews/web/Index.php
+++ b/src/main/php/de/thekid/crews/web/Index.php
@@ -1,8 +1,9 @@
 <?php namespace de\thekid\crews\web;
 
 use com\mongodb\{Database, Collection, Document};
+use de\thekid\crews\User;
 use util\Date;
-use web\frontend\{Handler, Get, Post, Param, View};
+use web\frontend\{Handler, Get, Post, Param, Value, View};
 
 #[Handler('/')]
 class Index {
@@ -27,7 +28,7 @@ class Index {
   }
 
   #[Post('/create')]
-  public function create(#[Param] $name, #[Param] $description) {
+  public function create(#[Value] User $user, #[Param] $name, #[Param] $description) {
     $name= trim($name);
 
     // Verify name is unique, return "Multiple Choices" status code
@@ -42,6 +43,7 @@ class Index {
     $insert= $this->groups->insert(new Document([
       'name'        => $name,
       'description' => $description,
+      'owner'       => $user->reference(),
       'created'     => Date::now(),
     ]));
     return View::empty()->header('HX-Redirect', "/group/{$insert->id()}");

--- a/src/test/php/de/thekid/crews/unittest/UserAttributesTest.php
+++ b/src/test/php/de/thekid/crews/unittest/UserAttributesTest.php
@@ -1,0 +1,39 @@
+<?php namespace de\thekid\crews\unittest;
+
+use de\thekid\crews\UserAttributes;
+use test\{Assert, Test};
+
+class UserAttributesTest {
+
+  #[Test]
+  public function can_create() {
+    new UserAttributes([]);
+  }
+
+  #[Test]
+  public function map_directly() {
+    $fixture= new UserAttributes(['handle' => '{{id}}']);
+    Assert::equals(
+      ['handle' => 'test'], 
+      [...$fixture(['id' => 'test'])],
+    );
+  }
+
+  #[Test]
+  public function map_concatenating() {
+    $fixture= new UserAttributes(['name' => '{{first}} {{last}}']);
+    Assert::equals(
+      ['name' => 'Timm Test'],
+      [...$fixture(['first' => 'Timm', 'last' => 'Test'])],
+    );
+  }
+
+  #[Test]
+  public function path_access() {
+    $fixture= new UserAttributes(['name' => '{{name.first}} {{name.middle.0}}. {{name.last}}']);
+    Assert::equals(
+      ['name' => 'Timm P. Test'],
+      [...$fixture(['name' => ['first' => 'Timm', 'middle' => 'PHP', 'last' => 'Test']])]
+    );
+  }
+}


### PR DESCRIPTION
This pull adds support for logging in via OAuth2. The details are configured in the `config.ini` file, an example of which is:

```ini
[mongo]
connect=mongodb://user:password@localhost/one
database=crews

[redis]
connect=redis://localhost

[oauth]
authorize=http://localhost:8443/oauth/common/authorize
token=http://localhost:8443/oauth/common/token
userinfo=http://localhost:8443/graph/me
client=client-id
secret=client-secret
scopes[]=user

[user]
handle="{{id}}"
first="{{givenName}}"
name="{{givenName}} {{surname}}"
mail="{{mail}}"
```